### PR TITLE
Add support for multiple batteries

### DIFF
--- a/lib/dsbbatmon.c
+++ b/lib/dsbbatmon.c
@@ -213,7 +213,7 @@ dsbbatmon_get_batt_info(dsbbatmon_t *bm)
 int
 dsbbatmon_init(dsbbatmon_t *bm)
 {
-	int i, units;
+	int units;
 
 	bm->lnbuf = NULL;
 	bm->errmsg[0] = '\0';
@@ -235,13 +235,10 @@ dsbbatmon_init(dsbbatmon_t *bm)
 		return (0);
 	} else if (units < 0)
 		ERROR(bm, -1, 0, true, "get_units()");
-	for (i = 0; i < units; i++) {
-		bm->unit = i;
-		if (dsbbatmon_poll(bm) == -1)
-			ERROR(bm, -1, 0, true, "dsbbatmon_poll()");
-		if (bm->have_batt)
-			break;
-	}
+	
+	bm->unit = ACPI_BATTERY_ALL_UNITS;
+	if (dsbbatmon_poll(bm) == -1)
+		ERROR(bm, -1, 0, true, "dsbbatmon_poll()");
 	if (!bm->have_batt)
 		bm->unit = 0;
 	return (1);


### PR DESCRIPTION
This removes the use of iterating over the battery units which then only reports the values of the first battery found.
Instead the special number ACPI_BATTERY_ALL_UNITS is used which accumulates the values of all batteries.

dsbbatmon then shows the sum for the remaining time of all batteries as well as the battery percentage for all batteries in one: 


```
$ acipconf -i0
...
Remaining capacity:	49%
Remaining time:		1:11
...
$ acpiconf -i1
...
Remaining capacity:	100%
Remaining time:		2:13
```

dsbbatmon shows 3:24h remaining time and 72% capacity.